### PR TITLE
Add Koyeb terraform configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*.tf @rojas-diego

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# IDE
+.vscode/
+
+# Terraform secrets
+secret.tfvars
+
+# Terraform state
+*.tfstate.*
+.terraform/
+terraform.tfstate*
+.terraform.*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Infra
+
+This repository contains the IaC definitions for the Noted infrastructure.
+
+## Koyeb
+
+To deploy Noted on Koyeb, you must use `terraform`.
+
+You first need to configure a Koyeb API token.
+
+```
+export KOYEB_TOKEN='<insert API token>'
+```
+
+Then, define a `secret.tfvars` file in the `koyeb` folder and fill in the following values.
+
+```
+// URI of the Mongo database used in production.
+mongo_uri = "<...>"
+```
+
+Finally execute the standard terraform flow.
+
+```
+cd koyeb
+terraform init
+terraform plan
+terraform apply -var-file="secret.tfvars"
+```
+
+## Vercel
+
+Coming soon.
+ 

--- a/koyeb/data-sources.tf
+++ b/koyeb/data-sources.tf
@@ -1,0 +1,15 @@
+data "koyeb_secret" "mongo_uri" {
+  name = "MONGO_URI"
+}
+
+data "koyeb_app" "noted" {
+  name = var.koyeb_app_name
+}
+
+data "koyeb_service" "gateway" {
+  slug = format("%s/%s", var.koyeb_app_name, var.koyeb_api_gateway_service_name)
+}
+
+data "koyeb_service" "accounts" {
+  slug = format("%s/%s", var.koyeb_app_name, var.koyeb_accounts_service_name)
+}

--- a/koyeb/resources.tf
+++ b/koyeb/resources.tf
@@ -1,0 +1,102 @@
+terraform {
+  required_providers {
+    koyeb = {
+      source = "koyeb/koyeb"
+    }
+  }
+}
+
+provider "koyeb" {
+}
+
+resource "koyeb_secret" "mongo_uri" {
+  name  = var.koyeb_mongo_uri_secret_name
+  value = var.mongo_uri
+}
+
+resource "koyeb_app" "noted" {
+  name = var.koyeb_app_name
+}
+
+resource "koyeb_service" "gateway" {
+  app_name = var.koyeb_app_name
+
+  definition {
+    name = var.koyeb_api_gateway_service_name
+    regions = ["par"]
+
+    instance_types {
+      type = "nano"
+    }
+
+    ports {
+      port = 3000
+      protocol = "http"
+    }
+
+    scalings {
+      min = 1
+      max = 1
+    }
+
+    env {
+      key = "API_GATEWAY_ACCOUNTS_SERVICE_ADDR"
+      value = "accounts.noted.koyeb:3000"
+    }
+
+    env {
+      key = "API_GATEWAY_RECOMMENDATIONS_SERVICE_ADDR"
+      value = "recommendations.noted.koyeb:3000"
+    }
+
+    routes {
+      path = "/"
+      port = 3000
+    }
+
+    docker {
+      image = "rojasdiego/noted-api-gateway"
+    }
+  }
+
+  depends_on = [
+    koyeb_app.noted
+  ]
+}
+
+resource "koyeb_service" "accounts" {
+  app_name = var.koyeb_app_name
+
+  definition {
+    name = var.koyeb_accounts_service_name
+    regions = ["par"]
+
+    instance_types {
+      type = "nano"
+    }
+
+    ports {
+      port = 3000
+      protocol = "tcp"
+    }
+
+    scalings {
+      min = 1
+      max = 1
+    }
+
+    env {
+      key = "ACCOUNTS_SERVICE_MONGO_URI"
+      secret = var.koyeb_mongo_uri_secret_name
+    }
+
+    docker {
+      image = "rojasdiego/noted-accounts-service"
+    }
+  }
+
+  depends_on = [
+    koyeb_app.noted,
+    koyeb_secret.mongo_uri
+  ]
+}

--- a/koyeb/variables.tf
+++ b/koyeb/variables.tf
@@ -1,0 +1,29 @@
+variable "koyeb_app_name" {
+  default = "noted"
+}
+
+variable "koyeb_api_gateway_service_name" {
+  default = "gateway"
+}
+
+variable "koyeb_accounts_service_name" {
+  default = "accounts"
+}
+
+variable "koyeb_notes_service_name" {
+  default = "notes"
+}
+
+variable "koyeb_recommendations_service_name" {
+  default = "recommendations"
+}
+
+variable "koyeb_mongo_uri_secret_name" {
+  default = "MONGO_URI"
+}
+
+variable "mongo_uri" {
+  description = "Address of the remote MongoDB database"
+  type = string
+  sensitive = true
+}


### PR DESCRIPTION
#### Description

This PR aims to make infrastructure management automated and collaborative. At the moment only I (@rojas-diego) can access our Koyeb account which runs the production of our backend. This means other team members cannot make changes to the configuration of our services. By managing our infrastructure with Terraform, everyone can submit pull requests to modify our infrastructure.

Updates noted-eip/api-gateway#7

#### Changelog

- [ENHANCEMENT] Add Koyeb infrastructure terraform definitions.
